### PR TITLE
Changed event.which to event.key

### DIFF
--- a/script.js
+++ b/script.js
@@ -415,14 +415,14 @@ setInterval(function () {
 }, 30000);
 
 document.addEventListener("keydown", function (event){
-    if (event.ctrlKey && event.which == 83) {
+    if (event.ctrlKey && event.key === 's') {
         event.preventDefault();
         saveGame();
     }
 }, false);
 
 document.addEventListener("keydown", function (event) {
-    if (event.ctrlKey && event.which == 84) {
+    if (event.ctrlKey && event.key === 'r') {
         resetGame();
     }
 }, false);


### PR DESCRIPTION
It helps make it clearer for developers to understand. `event.which == '83'` is less understandable than `event.key === 's'`.